### PR TITLE
Fix asset picker loading state and sizing

### DIFF
--- a/app/src/main/java/me/xdan/aperture/ui/screen/details/MediaDetailsModal.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/details/MediaDetailsModal.kt
@@ -54,6 +54,7 @@ import coil.request.ImageRequest
 import kotlinx.coroutines.delay
 import me.xdan.aperture.data.remote.api.TmdbApi
 import me.xdan.aperture.ui.component.ArtworkFallback
+import me.xdan.aperture.ui.component.expressive.ExpressiveWavyProgressIndicator
 import me.xdan.aperture.ui.theme.GlassBackground
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -98,8 +99,6 @@ fun MediaDetailsModal(
     LaunchedEffect(mediaId, episodeOnly) {
         if (mediaId != null) {
             displayedMedia = null
-            // Grouped show cards resume the most recently active episode. An
-            // individual episode popup must continue to honour the exact card.
             viewModel.loadMedia(mediaId, preferActiveEpisode = !episodeOnly)
         } else if (displayedMedia != null) {
             delay(320)
@@ -149,267 +148,247 @@ fun MediaDetailsModal(
             )
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
-        AnimatedVisibility(
-            visible = isVisible,
-            enter = fadeIn(animationSpec = tween(durationMillis = 200)),
-            exit = fadeOut(animationSpec = tween(durationMillis = 200)),
-            modifier = Modifier.fillMaxSize()
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.8f))
-            )
-        }
-
-        AnimatedVisibility(
-            visible = isVisible,
-            enter = slideInHorizontally(
-                initialOffsetX = { it },
-                animationSpec = tween(durationMillis = 300)
-            ),
-            exit = slideOutHorizontally(
-                targetOffsetX = { it },
-                animationSpec = tween(durationMillis = 300)
-            ),
-            modifier = Modifier.fillMaxSize()
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-            ) {
-                displayedMedia?.let { m ->
-                    val showEpisodeSelector = episodes.isNotEmpty() && !episodeOnly
-                    val artworkPath = if (episodeOnly && !m.stillPath.isNullOrBlank()) {
-                        m.stillPath
-                    } else {
-                        m.backdropPath
-                    }
-                    val heading = if (episodeOnly) {
-                        m.episodeTitle ?: "Episode ${m.episodeNumber ?: "?"}"
-                    } else {
-                        m.title
-                    }
-                    val subheading = if (episodeOnly) {
-                        buildString {
-                            append(m.title)
-                            m.seasonNumber?.let { append(" · Season $it") }
-                            m.episodeNumber?.let { append(" Episode $it") }
-                        }
-                    } else {
-                        m.year?.toString().orEmpty()
-                    }
-                    val artworkHeight = if (showEpisodeSelector) 120.dp else 160.dp
-                    Surface(
+                AnimatedVisibility(
+                    visible = isVisible,
+                    enter = fadeIn(animationSpec = tween(durationMillis = 200)),
+                    exit = fadeOut(animationSpec = tween(durationMillis = 200)),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Box(
                         modifier = Modifier
-                            .align(Alignment.CenterEnd)
-                            .fillMaxHeight()
-                            .width(500.dp)
-                            .focusProperties {
-                                canFocus = true
-                            },
-                        colors = SurfaceDefaults.colors(containerColor = GlassBackground),
-                        shape = RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp)
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(32.dp)
-                        ) {
-                            if (artworkPath.isNullOrBlank()) {
-                                ArtworkFallback(
-                                    title = heading,
-                                    isFocused = false,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(artworkHeight)
-                                        .clip(RoundedCornerShape(12.dp))
-                                )
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = 0.8f))
+                    )
+                }
+
+                AnimatedVisibility(
+                    visible = isVisible,
+                    enter = slideInHorizontally(
+                        initialOffsetX = { it },
+                        animationSpec = tween(durationMillis = 300)
+                    ),
+                    exit = slideOutHorizontally(
+                        targetOffsetX = { it },
+                        animationSpec = tween(durationMillis = 300)
+                    ),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        displayedMedia?.let { m ->
+                            val showEpisodeSelector = episodes.isNotEmpty() && !episodeOnly
+                            val artworkPath = if (episodeOnly && !m.stillPath.isNullOrBlank()) {
+                                m.stillPath
                             } else {
-                                AsyncImage(
-                                    model = ImageRequest.Builder(LocalContext.current)
-                                        .data(TmdbApi.IMAGE_BASE_URL + "w780" + artworkPath)
-                                        .crossfade(false)
-                                        .build(),
-                                    contentDescription = null,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(artworkHeight)
-                                        .clip(RoundedCornerShape(12.dp)),
-                                    contentScale = ContentScale.Crop
-                                )
+                                m.backdropPath
                             }
-                        
-                        Spacer(modifier = Modifier.height(14.dp))
-                        
-                        Text(
-                            text = heading,
-                            style = MaterialTheme.typography.headlineLarge,
-                            fontWeight = FontWeight.Bold
-                        )
-                        
-                        Text(
-                            text = subheading,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = Color.Gray
-                        )
-                        
-                        Spacer(modifier = Modifier.height(8.dp))
-                        
-                        Text(
-                            text = m.episodeOverview ?: m.overview ?: "No synopsis available.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = if (showEpisodeSelector) 2 else 4,
-                            overflow = TextOverflow.Ellipsis
-                        )
-
-                        Spacer(modifier = Modifier.weight(1f))
-
-                        if (showEpisodeSelector) {
-                            OutlinedButton(
-                                onClick = {
-                                    restoreEpisodeButtonAfterPicker = true
-                                    showEpisodePicker = true
-                                },
+                            val heading = if (episodeOnly) {
+                                m.episodeTitle ?: "Episode ${m.episodeNumber ?: "?"}"
+                            } else {
+                                m.title
+                            }
+                            val subheading = if (episodeOnly) {
+                                buildString {
+                                    append(m.title)
+                                    m.seasonNumber?.let { append(" · Season $it") }
+                                    m.episodeNumber?.let { append(" Episode $it") }
+                                }
+                            } else {
+                                m.year?.toString().orEmpty()
+                            }
+                            val artworkHeight = if (showEpisodeSelector) 120.dp else 160.dp
+                            Surface(
                                 modifier = Modifier
-                                    .fillMaxWidth()
-                                    .focusRequester(episodeButtonFocusRequester)
+                                    .align(Alignment.CenterEnd)
+                                    .fillMaxHeight()
+                                    .width(500.dp)
+                                    .focusProperties { canFocus = true },
+                                colors = SurfaceDefaults.colors(containerColor = GlassBackground),
+                                shape = RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp)
                             ) {
-                                Column(Modifier.weight(1f)) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(32.dp)
+                                ) {
+                                    if (artworkPath.isNullOrBlank()) {
+                                        ArtworkFallback(
+                                            title = heading,
+                                            isFocused = false,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(artworkHeight)
+                                                .clip(RoundedCornerShape(12.dp))
+                                        )
+                                    } else {
+                                        AsyncImage(
+                                            model = ImageRequest.Builder(LocalContext.current)
+                                                .data(TmdbApi.IMAGE_BASE_URL + "w780" + artworkPath)
+                                                .crossfade(false)
+                                                .build(),
+                                            contentDescription = null,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(artworkHeight)
+                                                .clip(RoundedCornerShape(12.dp)),
+                                            contentScale = ContentScale.Crop
+                                        )
+                                    }
+
+                                    Spacer(modifier = Modifier.height(14.dp))
                                     Text(
-                                        buildString {
-                                            m.seasonNumber?.let { append("Season $it") }
-                                            if (isNotEmpty() && m.episodeNumber != null) append(" · ")
-                                            m.episodeNumber?.let { append("Episode $it") }
-                                        }.ifBlank { "Choose episode" },
-                                        style = MaterialTheme.typography.labelMedium
+                                        text = heading,
+                                        style = MaterialTheme.typography.headlineLarge,
+                                        fontWeight = FontWeight.Bold
                                     )
                                     Text(
-                                        m.episodeTitle ?: "Choose episode",
-                                        style = MaterialTheme.typography.titleMedium,
-                                        maxLines = 1,
+                                        text = subheading,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = Color.Gray
+                                    )
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Text(
+                                        text = m.episodeOverview ?: m.overview ?: "No synopsis available.",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = if (showEpisodeSelector) 2 else 4,
                                         overflow = TextOverflow.Ellipsis
                                     )
-                                }
-                                Icon(Icons.Rounded.KeyboardArrowRight, contentDescription = "Choose episode")
-                            }
-                            Spacer(Modifier.height(10.dp))
-                        }
-                        
-                        Row(
-                            modifier = Modifier.heightIn(min = 52.dp),
-                            horizontalArrangement = Arrangement.spacedBy(10.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Button(
-                                onClick = { onPlay(m.id, false) },
-                                modifier = Modifier
-                                    .focusRequester(playButtonFocusRequester)
-                                    .focusProperties {
-                                        if (showEpisodeSelector) {
-                                            up = episodeButtonFocusRequester
-                                        }
-                                    }
-                                    .onFocusChanged { focusState ->
-                                        if (focusState.isFocused) {
-                                            if (ignoreNextPlayFocus) {
-                                                ignoreNextPlayFocus = false
-                                            } else {
-                                                waitForLeftRelease = true
-                                            }
-                                        }
-                                    }
-                                    .onKeyEvent { keyEvent ->
-                                        if (showEpisodeSelector && keyEvent.key == Key.DirectionUp) {
-                                            if (keyEvent.type == KeyEventType.KeyDown) {
-                                                episodeButtonFocusRequester.requestFocus()
-                                            }
-                                            true
-                                        } else if (keyEvent.key != Key.DirectionLeft) {
-                                            false
-                                        } else if (waitForLeftRelease) {
-                                            if (keyEvent.type == KeyEventType.KeyUp) {
-                                                waitForLeftRelease = false
-                                            }
-                                            true
-                                        } else when (keyEvent.type) {
-                                            KeyEventType.KeyDown -> true
-                                            KeyEventType.KeyUp -> {
-                                                closeModal()
-                                                true
-                                            }
-                                            else -> false
-                                        }
-                                    }
-                            ) {
-                                Icon(
-                                    if (hasBeenCompleted && !hasActiveProgress) {
-                                        Icons.Rounded.Replay
-                                    } else {
-                                        Icons.Rounded.PlayArrow
-                                    },
-                                    null
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(
-                                    when {
-                                        hasActiveProgress -> "Continue"
-                                        hasBeenCompleted -> "Rewatch"
-                                        else -> "Play"
-                                    }
-                                )
-                            }
 
-                            if (hasActiveProgress) {
-                                IconButton(onClick = { onPlay(m.id, true) }) {
-                                    Icon(Icons.Rounded.Replay, contentDescription = "Restart")
+                                    Spacer(modifier = Modifier.weight(1f))
+
+                                    if (showEpisodeSelector) {
+                                        OutlinedButton(
+                                            onClick = {
+                                                restoreEpisodeButtonAfterPicker = true
+                                                showEpisodePicker = true
+                                            },
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .focusRequester(episodeButtonFocusRequester)
+                                        ) {
+                                            Column(Modifier.weight(1f)) {
+                                                Text(
+                                                    buildString {
+                                                        m.seasonNumber?.let { append("Season $it") }
+                                                        if (isNotEmpty() && m.episodeNumber != null) append(" · ")
+                                                        m.episodeNumber?.let { append("Episode $it") }
+                                                    }.ifBlank { "Choose episode" },
+                                                    style = MaterialTheme.typography.labelMedium
+                                                )
+                                                Text(
+                                                    m.episodeTitle ?: "Choose episode",
+                                                    style = MaterialTheme.typography.titleMedium,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
+                                                )
+                                            }
+                                            Icon(Icons.Rounded.KeyboardArrowRight, contentDescription = "Choose episode")
+                                        }
+                                        Spacer(Modifier.height(10.dp))
+                                    }
+
+                                    Row(
+                                        modifier = Modifier.heightIn(min = 52.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Button(
+                                            onClick = { onPlay(m.id, false) },
+                                            modifier = Modifier
+                                                .focusRequester(playButtonFocusRequester)
+                                                .focusProperties {
+                                                    if (showEpisodeSelector) up = episodeButtonFocusRequester
+                                                }
+                                                .onFocusChanged { focusState ->
+                                                    if (focusState.isFocused) {
+                                                        if (ignoreNextPlayFocus) ignoreNextPlayFocus = false
+                                                        else waitForLeftRelease = true
+                                                    }
+                                                }
+                                                .onKeyEvent { keyEvent ->
+                                                    if (showEpisodeSelector && keyEvent.key == Key.DirectionUp) {
+                                                        if (keyEvent.type == KeyEventType.KeyDown) {
+                                                            episodeButtonFocusRequester.requestFocus()
+                                                        }
+                                                        true
+                                                    } else if (keyEvent.key != Key.DirectionLeft) {
+                                                        false
+                                                    } else if (waitForLeftRelease) {
+                                                        if (keyEvent.type == KeyEventType.KeyUp) waitForLeftRelease = false
+                                                        true
+                                                    } else when (keyEvent.type) {
+                                                        KeyEventType.KeyDown -> true
+                                                        KeyEventType.KeyUp -> {
+                                                            closeModal()
+                                                            true
+                                                        }
+                                                        else -> false
+                                                    }
+                                                }
+                                        ) {
+                                            Icon(
+                                                if (hasBeenCompleted && !hasActiveProgress) Icons.Rounded.Replay
+                                                else Icons.Rounded.PlayArrow,
+                                                null
+                                            )
+                                            Spacer(Modifier.width(8.dp))
+                                            Text(
+                                                when {
+                                                    hasActiveProgress -> "Continue"
+                                                    hasBeenCompleted -> "Rewatch"
+                                                    else -> "Play"
+                                                }
+                                            )
+                                        }
+
+                                        if (hasActiveProgress) {
+                                            IconButton(onClick = { onPlay(m.id, true) }) {
+                                                Icon(Icons.Rounded.Replay, contentDescription = "Restart")
+                                            }
+                                        }
+
+                                        OutlinedButton(onClick = { viewModel.toggleFavorite(m.id) }) {
+                                            Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null)
+                                            Spacer(Modifier.width(8.dp))
+                                            Text(if (m.isFavorite) "Remove from My List" else "My List")
+                                        }
+                                        IconButton(
+                                            onClick = {
+                                                showAssetPicker = true
+                                                viewModel.findAssetCandidates()
+                                            }
+                                        ) {
+                                            Icon(Icons.Rounded.ImageSearch, contentDescription = "Select artwork")
+                                        }
+                                    }
                                 }
                             }
-                            
-                            OutlinedButton(
-                                onClick = { viewModel.toggleFavorite(m.id) }
-                            ) {
-                                Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null)
-                                Spacer(Modifier.width(8.dp))
-                                Text(if (m.isFavorite) "Remove from My List" else "My List")
-                            }
-                            IconButton(
-                                onClick = {
-                                    showAssetPicker = true
-                                    viewModel.findAssetCandidates()
-                                }
-                            ) {
-                                Icon(Icons.Rounded.ImageSearch, contentDescription = "Select artwork")
-                            }
-                        }
                         }
                     }
                 }
-            }
-        }
-        if (showAssetPicker) {
-            AssetPickerDialog(
-                candidates = assetCandidates,
-                loading = isLoadingAssets,
-                onSelect = {
-                    viewModel.selectAssetCandidate(it)
-                    showAssetPicker = false
-                },
-                onQueryChange = viewModel::findAssetCandidates,
-                onDismiss = { showAssetPicker = false }
-            )
-        }
-        if (showEpisodePicker && displayedMedia != null) {
-            EpisodePickerDialog(
-                episodes = episodes,
-                selectedEpisodeId = displayedMedia!!.id,
-                onSelectEpisode = { episodeId ->
-                    viewModel.selectEpisode(episodeId)
-                    showEpisodePicker = false
-                },
-                onDismiss = { showEpisodePicker = false }
-            )
-        }
+
+                if (showAssetPicker) {
+                    AssetPickerDialog(
+                        candidates = assetCandidates,
+                        loading = isLoadingAssets,
+                        onSelect = {
+                            viewModel.selectAssetCandidate(it)
+                            showAssetPicker = false
+                        },
+                        onQueryChange = viewModel::findAssetCandidates,
+                        onDismiss = { showAssetPicker = false }
+                    )
+                }
+                if (showEpisodePicker && displayedMedia != null) {
+                    EpisodePickerDialog(
+                        episodes = episodes,
+                        selectedEpisodeId = displayedMedia!!.id,
+                        onSelectEpisode = { episodeId ->
+                            viewModel.selectEpisode(episodeId)
+                            showEpisodePicker = false
+                        },
+                        onDismiss = { showEpisodePicker = false }
+                    )
+                }
             }
         }
     }
@@ -465,15 +444,11 @@ private fun EpisodePickerDialog(
                             onClick = { selectedSeason = season },
                             shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(50)),
                             colors = ClickableSurfaceDefaults.colors(
-                                containerColor = if (season == selectedSeason) {
-                                    MaterialTheme.colorScheme.primaryContainer
-                                } else MaterialTheme.colorScheme.surfaceVariant
+                                containerColor = if (season == selectedSeason) MaterialTheme.colorScheme.primaryContainer
+                                else MaterialTheme.colorScheme.surfaceVariant
                             )
                         ) {
-                            Text(
-                                "Season $season",
-                                modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp)
-                            )
+                            Text("Season $season", modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp))
                         }
                     }
                 }
@@ -481,33 +456,22 @@ private fun EpisodePickerDialog(
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.weight(1f),
-                    // Focused TV surfaces scale beyond their normal bounds.
-                    // Keep that animation safely inside the picker on all sides.
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     lazyItems(seasonEpisodes, key = { it.id }) { episode ->
                         val isEntryEpisode = episode.id == seasonEpisodes.getOrNull(selectedIndex)?.id
                         Surface(
-                            onClick = {
-                                onSelectEpisode(episode.id)
-                            },
+                            onClick = { onSelectEpisode(episode.id) },
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .then(
-                                    if (isEntryEpisode) Modifier.focusRequester(episodeFocusRequester)
-                                    else Modifier
-                                ),
+                                .then(if (isEntryEpisode) Modifier.focusRequester(episodeFocusRequester) else Modifier),
                             shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(16.dp)),
                             colors = ClickableSurfaceDefaults.colors(
-                                containerColor = if (episode.id == selectedEpisodeId) {
-                                    MaterialTheme.colorScheme.primaryContainer
-                                } else MaterialTheme.colorScheme.surfaceVariant
+                                containerColor = if (episode.id == selectedEpisodeId) MaterialTheme.colorScheme.primaryContainer
+                                else MaterialTheme.colorScheme.surfaceVariant
                             )
                         ) {
-                            // Let the surface supply its focused content colour.
-                            // A hard-coded onSurfaceVariant colour becomes unreadable
-                            // against the light focused container on TV.
                             Row(
                                 Modifier.fillMaxWidth().padding(12.dp),
                                 verticalAlignment = Alignment.CenterVertically
@@ -516,22 +480,15 @@ private fun EpisodePickerDialog(
                                     AsyncImage(
                                         model = TmdbApi.IMAGE_BASE_URL + "w300" + episode.stillPath,
                                         contentDescription = null,
-                                        modifier = Modifier
-                                            .width(132.dp)
-                                            .height(74.dp)
-                                            .clip(RoundedCornerShape(10.dp)),
+                                        modifier = Modifier.width(132.dp).height(74.dp).clip(RoundedCornerShape(10.dp)),
                                         contentScale = ContentScale.Crop
                                     )
                                     Spacer(Modifier.width(14.dp))
                                 }
                                 Column(Modifier.weight(1f)) {
+                                    Text("Episode ${episode.episodeNumber ?: "?"}", style = MaterialTheme.typography.labelMedium)
                                     Text(
-                                        "Episode ${episode.episodeNumber ?: "?"}",
-                                        style = MaterialTheme.typography.labelMedium
-                                    )
-                                    Text(
-                                        episode.episodeTitle
-                                            ?: episode.filePath.substringAfterLast('/').substringBeforeLast('.'),
+                                        episode.episodeTitle ?: episode.filePath.substringAfterLast('/').substringBeforeLast('.'),
                                         style = MaterialTheme.typography.titleMedium,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis
@@ -568,11 +525,13 @@ private fun AssetPickerDialog(
     }
     Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
         Surface(
-            modifier = Modifier.fillMaxSize().padding(52.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
             shape = RoundedCornerShape(28.dp),
             colors = SurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surface)
         ) {
-            Column(Modifier.padding(28.dp)) {
+            Column(Modifier.padding(32.dp)) {
                 Text("Choose artwork and metadata", style = MaterialTheme.typography.headlineMedium)
                 Text("Correct the title, then select the matching TMDB result.")
                 Spacer(Modifier.height(12.dp))
@@ -594,17 +553,27 @@ private fun AssetPickerDialog(
                 )
                 Spacer(Modifier.height(20.dp))
                 when {
-                    loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        me.xdan.aperture.ui.component.expressive.ExpressiveLoadingIndicator()
+                    loading -> Box(
+                        Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        ExpressiveWavyProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
+                            strokeWidth = 8.dp
+                        )
                     }
                     candidates.isEmpty() -> Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
                         Text("No matching artwork found.")
                     }
                     else -> LazyVerticalGrid(
-                        columns = GridCells.Adaptive(112.dp),
+                        columns = GridCells.Adaptive(160.dp),
                         modifier = Modifier.weight(1f),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        contentPadding = PaddingValues(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         gridItems(candidates, key = { it.id }) { candidate ->
                             Surface(
@@ -617,10 +586,7 @@ private fun AssetPickerDialog(
                                 ),
                                 border = ClickableSurfaceDefaults.border(
                                     focusedBorder = Border(
-                                        border = androidx.compose.foundation.BorderStroke(
-                                            3.dp,
-                                            Color.White
-                                        ),
+                                        border = androidx.compose.foundation.BorderStroke(3.dp, Color.White),
                                         shape = RoundedCornerShape(12.dp)
                                     )
                                 )


### PR DESCRIPTION
### Changes
- use the Material 3 Expressive wavy progress indicator while asset candidates are loading
- enlarge the artwork picker window by reducing its outer inset
- increase artwork card sizing and grid spacing so focused cards have room to scale without feeling cramped
- add grid content padding to keep focused cards away from the picker edges

The picker remains TV-friendly while giving the artwork cards considerably more breathing room.