### PR TITLE
Make theme colours more expressive

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "me.xdan.aperture"
         minSdk = 27
         targetSdk = 37
-        versionCode = 12
-        versionName = "v0.4.2-alpha"
+        versionCode = 13
+        versionName = "v0.5.0-alpha"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/java/me/xdan/aperture/ui/component/ApertureBrandMark.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/component/ApertureBrandMark.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
-import androidx.tv.material3.MaterialTheme
+import me.xdan.aperture.ui.theme.ApertureTheme
 
 private const val BladeSpinDurationMillis = 650
 private val BladeSpinEasing = CubicBezierEasing(0.42f, 0f, 0.58f, 1f)
@@ -27,7 +27,7 @@ private val BladeSpinEasing = CubicBezierEasing(0.42f, 0f, 0.58f, 1f)
 @Composable
 fun ApertureBrandMark(
     modifier: Modifier = Modifier,
-    accent: Color = MaterialTheme.colorScheme.primary,
+    accent: Color = ApertureTheme.brandAccent,
     spinBlades: Boolean = false,
     spinKey: Any? = null
 ) {

--- a/app/src/main/java/me/xdan/aperture/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/navigation/NavGraph.kt
@@ -38,6 +38,7 @@ import me.xdan.aperture.ui.component.ApertureBrandMark
 import me.xdan.aperture.ui.screen.actions.MediaActionsViewModel
 import me.xdan.aperture.ui.screen.onboarding.AppTutorial
 import me.xdan.aperture.ui.theme.ApertureBrandFontFamily
+import me.xdan.aperture.ui.theme.ApertureTheme
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -432,6 +433,7 @@ fun NavGraph(
                                 leadingContent = { Icon(Icons.Rounded.Settings, contentDescription = null) }
                             ) {
                                 Text("Settings")
+                            }
                             }
                         }
                     }

--- a/app/src/main/java/me/xdan/aperture/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/navigation/NavGraph.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavBackStack
@@ -285,10 +286,25 @@ fun NavGraph(
                 NavigationDrawer(
                     drawerState = drawerState,
                     drawerContent = { drawerValue ->
-                        Column(
-                            modifier = Modifier
-                                .padding(16.dp)
-                                .fillMaxHeight(),
+                        Surface(
+                            modifier = Modifier.fillMaxHeight(),
+                            colors = SurfaceDefaults.colors(
+                                containerColor = if (ApertureTheme.isMaterialTv) {
+                                    Color.White
+                                } else {
+                                    MaterialTheme.colorScheme.surface
+                                },
+                                contentColor = if (ApertureTheme.isMaterialTv) {
+                                    Color(0xFF1A191C)
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                }
+                            )
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .padding(16.dp)
+                                    .fillMaxHeight(),
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             // Logo and Title

--- a/app/src/main/java/me/xdan/aperture/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/home/HomeScreen.kt
@@ -72,14 +72,18 @@ fun HomeScreen(
                     Spacer(Modifier.height(16.dp))
                     Button(
                         onClick = { viewModel.softRefresh() },
-                        colors = ButtonDefaults.colors(
-                            containerColor = ApertureTheme.colorScheme.primary,
-                            contentColor = ApertureTheme.colorScheme.onPrimary,
-                            focusedContainerColor = ApertureTheme.colorScheme.primaryContainer,
-                            focusedContentColor = ApertureTheme.colorScheme.onPrimaryContainer,
-                            pressedContainerColor = ApertureTheme.colorScheme.primaryContainer,
-                            pressedContentColor = ApertureTheme.colorScheme.onPrimaryContainer
-                        )
+                        colors = if (ApertureTheme.isMaterialTv) {
+                            ButtonDefaults.colors()
+                        } else {
+                            ButtonDefaults.colors(
+                                containerColor = ApertureTheme.colorScheme.primary.copy(alpha = 0.72f),
+                                contentColor = ApertureTheme.colorScheme.onPrimary,
+                                focusedContainerColor = ApertureTheme.colorScheme.primary,
+                                focusedContentColor = ApertureTheme.colorScheme.onPrimary,
+                                pressedContainerColor = ApertureTheme.colorScheme.primary,
+                                pressedContentColor = ApertureTheme.colorScheme.onPrimary
+                            )
+                        }
                     ) {
                         Text("Rescan")
                     }
@@ -388,14 +392,18 @@ private fun FeaturedCarousel(
                                     onContentFocused(watchNowFocusRequester)
                                 }
                             },
-                        colors = ButtonDefaults.colors(
-                            containerColor = ApertureTheme.colorScheme.primary,
-                            contentColor = ApertureTheme.colorScheme.onPrimary,
-                            focusedContainerColor = ApertureTheme.colorScheme.primaryContainer,
-                            focusedContentColor = ApertureTheme.colorScheme.onPrimaryContainer,
-                            pressedContainerColor = ApertureTheme.colorScheme.primaryContainer,
-                            pressedContentColor = ApertureTheme.colorScheme.onPrimaryContainer
-                        )
+                        colors = if (ApertureTheme.isMaterialTv) {
+                            ButtonDefaults.colors()
+                        } else {
+                            ButtonDefaults.colors(
+                                containerColor = ApertureTheme.colorScheme.primary.copy(alpha = 0.72f),
+                                contentColor = ApertureTheme.colorScheme.onPrimary,
+                                focusedContainerColor = ApertureTheme.colorScheme.primary,
+                                focusedContentColor = ApertureTheme.colorScheme.onPrimary,
+                                pressedContainerColor = ApertureTheme.colorScheme.primary,
+                                pressedContentColor = ApertureTheme.colorScheme.onPrimary
+                            )
+                        }
                     ) {
                         val progress = progressMap[media.id] ?: 0f
                         Text(

--- a/app/src/main/java/me/xdan/aperture/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/home/HomeScreen.kt
@@ -70,7 +70,17 @@ fun HomeScreen(
                 ) {
                     Text("No media found on device.")
                     Spacer(Modifier.height(16.dp))
-                    Button(onClick = { viewModel.softRefresh() }) {
+                    Button(
+                        onClick = { viewModel.softRefresh() },
+                        colors = ButtonDefaults.colors(
+                            containerColor = ApertureTheme.colorScheme.primary,
+                            contentColor = ApertureTheme.colorScheme.onPrimary,
+                            focusedContainerColor = ApertureTheme.colorScheme.primaryContainer,
+                            focusedContentColor = ApertureTheme.colorScheme.onPrimaryContainer,
+                            pressedContainerColor = ApertureTheme.colorScheme.primaryContainer,
+                            pressedContentColor = ApertureTheme.colorScheme.onPrimaryContainer
+                        )
+                    ) {
                         Text("Rescan")
                     }
                 }
@@ -277,9 +287,9 @@ private fun FeaturedCarousel(
                 border = androidx.compose.foundation.BorderStroke(
                     width = if (focusActiveSpotlight) 3.dp else 1.dp,
                     color = if (focusActiveSpotlight) {
-                        Color.White
+                        ApertureTheme.colorScheme.primary
                     } else {
-                        Color.White.copy(alpha = 0.28f)
+                        ApertureTheme.colorScheme.primary.copy(alpha = 0.28f)
                     }
                 ),
                 shape = spotlightShape
@@ -377,7 +387,15 @@ private fun FeaturedCarousel(
                                     onFocusKeyChanged(HOME_SPOTLIGHT_FOCUS_KEY)
                                     onContentFocused(watchNowFocusRequester)
                                 }
-                            }
+                            },
+                        colors = ButtonDefaults.colors(
+                            containerColor = ApertureTheme.colorScheme.primary,
+                            contentColor = ApertureTheme.colorScheme.onPrimary,
+                            focusedContainerColor = ApertureTheme.colorScheme.primaryContainer,
+                            focusedContentColor = ApertureTheme.colorScheme.onPrimaryContainer,
+                            pressedContainerColor = ApertureTheme.colorScheme.primaryContainer,
+                            pressedContentColor = ApertureTheme.colorScheme.onPrimaryContainer
+                        )
                     ) {
                         val progress = progressMap[media.id] ?: 0f
                         Text(
@@ -418,6 +436,7 @@ private fun HomeMediaRow(
         Text(
             text = row.title,
             style = MaterialTheme.typography.titleLarge,
+            color = ApertureTheme.colorScheme.primary,
             modifier = Modifier.padding(start = 16.dp, bottom = 8.dp)
         )
         LazyRow(

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -20,11 +20,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.GridCells
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.DeleteSweep
@@ -283,7 +285,7 @@ fun SettingsScreen(
                         ExpressiveToggle(
                             checked = spotlightSettings.roundedSpotlight,
                             onCheckedChange = null,
-                            isFocused = false // Managed by parent item
+                            isFocused = false
                         )
                     }
                 )
@@ -1276,43 +1278,116 @@ private fun ThemePickerDialog(
             contentAlignment = Alignment.Center
         ) {
             Surface(
-                modifier = Modifier.width(620.dp).heightIn(max = 620.dp),
+                modifier = Modifier.width(820.dp).heightIn(max = 720.dp),
                 shape = ApertureTheme.shapes.dialog,
                 colors = SurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surface)
             ) {
                 Column(Modifier.padding(ApertureTheme.spacing.huge)) {
                     Text("Choose a theme", style = MaterialTheme.typography.headlineSmall)
                     Text(
-                        "The preview updates Aperture, the player OSD and Quick Menu immediately.",
+                        "Choose a palette for Aperture. Material TV keeps the Google TV look, while the other themes carry their colour through the interface.",
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
                     )
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
-                    LazyColumn(
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(3),
                         modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.small)
+                        verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium),
+                        horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
                     ) {
-                        itemsIndexed(ApertureThemeOptions, key = { _, option -> option.id }) { index, option ->
+                        items(ApertureThemeOptions, key = { it.id }) { option ->
+                            val selected = option.id == selectedThemeId
                             Surface(
                                 onClick = { onSelect(option.id) },
                                 modifier = Modifier.fillMaxWidth().then(
-                                    if (index == 0) Modifier.focusRequester(firstRequester) else Modifier
+                                    if (option.id == ApertureThemeOptions.first().id) Modifier.focusRequester(firstRequester) else Modifier
                                 ),
-                                shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+                                shape = ClickableSurfaceDefaults.shape(ApertureTheme.shapes.card),
                                 colors = ClickableSurfaceDefaults.colors(
-                                    containerColor = if (option.id == selectedThemeId) {
+                                    containerColor = if (selected) {
                                         MaterialTheme.colorScheme.primaryContainer
-                                    } else MaterialTheme.colorScheme.surfaceVariant
+                                    } else {
+                                        MaterialTheme.colorScheme.surfaceVariant
+                                    },
+                                    focusedContainerColor = MaterialTheme.colorScheme.primaryContainer
+                                ),
+                                scale = ClickableSurfaceDefaults.scale(
+                                    focusedScale = 1.025f,
+                                    pressedScale = 0.98f
+                                ),
+                                border = ClickableSurfaceDefaults.border(
+                                    focusedBorder = Border(
+                                        border = androidx.compose.foundation.BorderStroke(
+                                            2.dp,
+                                            MaterialTheme.colorScheme.primary
+                                        ),
+                                        shape = ApertureTheme.shapes.card
+                                    )
                                 )
                             ) {
-                                Row(
-                                    Modifier.padding(horizontal = 18.dp, vertical = 12.dp),
-                                    verticalAlignment = Alignment.CenterVertically
+                                Column(
+                                    modifier = Modifier.padding(ApertureTheme.spacing.medium),
+                                    horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
-                                    Box(Modifier.size(28.dp).background(option.preview, CircleShape))
-                                    Spacer(Modifier.width(14.dp))
-                                    Text(option.label, style = MaterialTheme.typography.titleMedium)
-                                    Spacer(Modifier.weight(1f))
-                                    if (option.id == selectedThemeId) Text("Selected")
+                                    Box(
+                                        modifier = Modifier
+                                            .size(88.dp)
+                                            .border(
+                                                width = if (selected) 3.dp else 1.dp,
+                                                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                                                shape = CircleShape
+                                            )
+                                            .background(MaterialTheme.colorScheme.surface, CircleShape)
+                                    ) {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(48.dp)
+                                                .background(option.primary)
+                                        )
+                                        Row(
+                                            modifier = Modifier
+                                                .align(Alignment.BottomCenter)
+                                                .fillMaxWidth()
+                                                .height(40.dp)
+                                        ) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .fillMaxSize()
+                                                    .background(option.secondary)
+                                            )
+                                            Box(
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .fillMaxSize()
+                                                    .background(option.tertiary)
+                                            )
+                                        }
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .border(
+                                                    width = 1.dp,
+                                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
+                                                    shape = CircleShape
+                                                )
+                                        )
+                                    }
+                                    Spacer(Modifier.height(ApertureTheme.spacing.small))
+                                    Text(
+                                        option.label,
+                                        style = MaterialTheme.typography.titleSmall,
+                                        textAlign = TextAlign.Center
+                                    )
+                                    if (selected) {
+                                        Spacer(Modifier.height(2.dp))
+                                        Text(
+                                            "Selected",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -1511,7 +1586,6 @@ private fun SpotlightDaysDialog(
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
                     )
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
-                    
                     var isSliderFocused by remember { mutableStateOf(false) }
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         ExpressiveSlider(
@@ -1531,16 +1605,13 @@ private fun SpotlightDaysDialog(
                             textAlign = TextAlign.Center
                         )
                     }
-                    
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.small),
                         modifier = Modifier.align(Alignment.End)
                     ) {
                         androidx.tv.material3.OutlinedButton(onClick = onDismiss) { Text("Cancel") }
-                        Button(
-                            onClick = { onSave(days) }
-                        ) { Text("Save") }
+                        Button(onClick = { onSave(days) }) { Text("Save") }
                     }
                 }
             }

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -1295,7 +1296,7 @@ private fun ThemePickerDialog(
                         verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium),
                         horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
                     ) {
-                        items(ApertureThemeOptions, key = { option -> option.id }) { option ->
+                        gridItems(ApertureThemeOptions, key = { option -> option.id }) { option ->
                             val selected = option.id == selectedThemeId
                             Surface(
                                 onClick = { onSelect(option.id) },

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -1295,26 +1296,46 @@ private fun ThemePickerDialog(
                     )
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
                     LazyColumn(
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentPadding = PaddingValues(
+                            top = 12.dp,
+                            bottom = 8.dp
+                        ),
                         verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
                     ) {
-                        items(themeRows, key = { row -> row.firstOrNull()?.id ?: "empty" }) { row ->
+                        items(
+                            themeRows,
+                            key = { row -> row.firstOrNull()?.id ?: "empty" }
+                        ) { row ->
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
+                                horizontalArrangement = Arrangement.spacedBy(
+                                    ApertureTheme.spacing.medium
+                                )
                             ) {
                                 repeat(3) { index ->
                                     val option = row.getOrNull(index)
+
                                     if (option != null) {
                                         ThemeOptionCard(
                                             option = option,
                                             selected = option.id == selectedThemeId,
-                                            firstRequester = if (index == 0 && row === themeRows.first()) firstRequester else null,
+                                            firstRequester = if (
+                                                index == 0 && row === themeRows.first()
+                                            ) firstRequester else null,
                                             onSelect = onSelect,
-                                            modifier = Modifier.weight(1f)
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .height(176.dp)
                                         )
                                     } else {
-                                        Spacer(Modifier.weight(1f))
+                                        Spacer(
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .height(176.dp)
+                                        )
                                     }
                                 }
                             }
@@ -1340,7 +1361,13 @@ private fun ThemeOptionCard(
     Surface(
         onClick = { onSelect(option.id) },
         modifier = modifier
-            .then(if (firstRequester != null) Modifier.focusRequester(firstRequester) else Modifier),
+            .then(
+                if (firstRequester != null) {
+                    Modifier.focusRequester(firstRequester)
+                } else {
+                    Modifier
+                }
+            ),
         shape = ClickableSurfaceDefaults.shape(ApertureTheme.shapes.poster),
         colors = ClickableSurfaceDefaults.colors(
             containerColor = if (selected) {
@@ -1365,23 +1392,47 @@ private fun ThemeOptionCard(
         )
     ) {
         Column(
-            modifier = Modifier.padding(ApertureTheme.spacing.medium),
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(ApertureTheme.spacing.medium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            ThemeColourSwatch(option = option, selected = selected)
-            Spacer(Modifier.height(ApertureTheme.spacing.small))
-            Text(
-                text = option.label,
-                style = MaterialTheme.typography.titleSmall,
-                textAlign = TextAlign.Center
+            ThemeColourSwatch(
+                option = option,
+                selected = selected
             )
-            if (selected) {
-                Spacer(Modifier.height(2.dp))
+
+            Spacer(Modifier.height(ApertureTheme.spacing.small))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(32.dp),
+                contentAlignment = Alignment.Center
+            ) {
                 Text(
-                    "Selected",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.primary
+                    text = option.label,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.titleSmall,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2
                 )
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(18.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                if (selected) {
+                    Text(
+                        "Selected",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -1420,20 +1420,20 @@ private fun ThemeOptionCard(
                 )
             }
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(18.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                if (selected) {
-                    Text(
-                        "Selected",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
+//            Box(
+//                modifier = Modifier
+//                    .fillMaxWidth()
+//                    .height(18.dp),
+//                contentAlignment = Alignment.Center
+//            ) {
+//                if (selected) {
+//                    Text(
+//                        "Selected",
+//                        style = MaterialTheme.typography.labelSmall,
+//                        color = MaterialTheme.colorScheme.primary
+//                    )
+//                }
+//            }
         }
     }
 }

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -21,8 +21,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -1295,14 +1295,18 @@ private fun ThemePickerDialog(
                         verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium),
                         horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
                     ) {
-                        items(ApertureThemeOptions, key = { it.id }) { option ->
+                        items(ApertureThemeOptions, key = { option -> option.id }) { option ->
                             val selected = option.id == selectedThemeId
                             Surface(
                                 onClick = { onSelect(option.id) },
-                                modifier = Modifier.fillMaxWidth().then(
-                                    if (option.id == ApertureThemeOptions.first().id) Modifier.focusRequester(firstRequester) else Modifier
-                                ),
-                                shape = ClickableSurfaceDefaults.shape(ApertureTheme.shapes.card),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .then(
+                                        if (option.id == ApertureThemeOptions.first().id) {
+                                            Modifier.focusRequester(firstRequester)
+                                        } else Modifier
+                                    ),
+                                shape = ClickableSurfaceDefaults.shape(ApertureTheme.shapes.poster),
                                 colors = ClickableSurfaceDefaults.colors(
                                     containerColor = if (selected) {
                                         MaterialTheme.colorScheme.primaryContainer
@@ -1321,7 +1325,7 @@ private fun ThemePickerDialog(
                                             2.dp,
                                             MaterialTheme.colorScheme.primary
                                         ),
-                                        shape = ApertureTheme.shapes.card
+                                        shape = ApertureTheme.shapes.poster
                                     )
                                 )
                             ) {
@@ -1334,7 +1338,11 @@ private fun ThemePickerDialog(
                                             .size(88.dp)
                                             .border(
                                                 width = if (selected) 3.dp else 1.dp,
-                                                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                                                color = if (selected) {
+                                                    MaterialTheme.colorScheme.primary
+                                                } else {
+                                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                                                },
                                                 shape = CircleShape
                                             )
                                             .background(MaterialTheme.colorScheme.surface, CircleShape)
@@ -1376,14 +1384,14 @@ private fun ThemePickerDialog(
                                     }
                                     Spacer(Modifier.height(ApertureTheme.spacing.small))
                                     Text(
-                                        option.label,
+                                        text = option.label,
                                         style = MaterialTheme.typography.titleSmall,
                                         textAlign = TextAlign.Center
                                     )
                                     if (selected) {
                                         Spacer(Modifier.height(2.dp))
                                         Text(
-                                            "Selected",
+                                            text = "Selected",
                                             style = MaterialTheme.typography.labelSmall,
                                             color = MaterialTheme.colorScheme.primary
                                         )

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -1328,13 +1328,13 @@ private fun ThemePickerDialog(
                                             onSelect = onSelect,
                                             modifier = Modifier
                                                 .weight(1f)
-                                                .height(176.dp)
+                                                .height(152.dp)
                                         )
                                     } else {
                                         Spacer(
                                             modifier = Modifier
                                                 .weight(1f)
-                                                .height(176.dp)
+                                                .height(152.dp)
                                         )
                                     }
                                 }
@@ -1394,7 +1394,7 @@ private fun ThemeOptionCard(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(ApertureTheme.spacing.medium),
+                .padding(horizontal = 10.dp, vertical = 8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
@@ -1403,7 +1403,7 @@ private fun ThemeOptionCard(
                 selected = selected
             )
 
-            Spacer(Modifier.height(ApertureTheme.spacing.small))
+            Spacer(Modifier.height(4.dp))
 
             Box(
                 modifier = Modifier

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -21,13 +21,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.GridCells
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.DeleteSweep
@@ -1272,7 +1270,13 @@ private fun ThemePickerDialog(
     onDismiss: () -> Unit
 ) {
     val firstRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { delay(80); runCatching { firstRequester.requestFocus() } }
+    val themeRows = remember { ApertureThemeOptions.chunked(3) }
+
+    LaunchedEffect(Unit) {
+        delay(80)
+        runCatching { firstRequester.requestFocus() }
+    }
+
     Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
         Box(
             Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.78f)),
@@ -1290,67 +1294,27 @@ private fun ThemePickerDialog(
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
                     )
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(3),
+                    LazyColumn(
                         modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium),
-                        horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
+                        verticalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
                     ) {
-                        gridItems(ApertureThemeOptions, key = { option -> option.id }) { option ->
-                            val selected = option.id == selectedThemeId
-                            Surface(
-                                onClick = { onSelect(option.id) },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .then(
-                                        if (option.id == ApertureThemeOptions.first().id) {
-                                            Modifier.focusRequester(firstRequester)
-                                        } else Modifier
-                                    ),
-                                shape = ClickableSurfaceDefaults.shape(ApertureTheme.shapes.poster),
-                                colors = ClickableSurfaceDefaults.colors(
-                                    containerColor = if (selected) {
-                                        MaterialTheme.colorScheme.primaryContainer
-                                    } else {
-                                        MaterialTheme.colorScheme.surfaceVariant
-                                    },
-                                    focusedContainerColor = MaterialTheme.colorScheme.primaryContainer
-                                ),
-                                scale = ClickableSurfaceDefaults.scale(
-                                    focusedScale = 1.025f,
-                                    pressedScale = 0.98f
-                                ),
-                                border = ClickableSurfaceDefaults.border(
-                                    focusedBorder = Border(
-                                        border = androidx.compose.foundation.BorderStroke(
-                                            2.dp,
-                                            MaterialTheme.colorScheme.primary
-                                        ),
-                                        shape = ApertureTheme.shapes.poster
-                                    )
-                                )
+                        items(themeRows, key = { row -> row.firstOrNull()?.id ?: "empty" }) { row ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.medium)
                             ) {
-                                Column(
-                                    modifier = Modifier.padding(ApertureTheme.spacing.medium),
-                                    horizontalAlignment = Alignment.CenterHorizontally
-                                ) {
-                                    ThemeColourSwatch(
-                                        option = option,
-                                        selected = selected
-                                    )
-                                    Spacer(Modifier.height(ApertureTheme.spacing.small))
-                                    Text(
-                                        text = option.label,
-                                        style = MaterialTheme.typography.titleSmall,
-                                        textAlign = TextAlign.Center
-                                    )
-                                    if (selected) {
-                                        Spacer(Modifier.height(2.dp))
-                                        Text(
-                                            "Selected",
-                                            style = MaterialTheme.typography.labelSmall,
-                                            color = MaterialTheme.colorScheme.primary
+                                repeat(3) { index ->
+                                    val option = row.getOrNull(index)
+                                    if (option != null) {
+                                        ThemeOptionCard(
+                                            option = option,
+                                            selected = option.id == selectedThemeId,
+                                            firstRequester = if (index == 0 && row === themeRows.first()) firstRequester else null,
+                                            onSelect = onSelect,
+                                            modifier = Modifier.weight(1f)
                                         )
+                                    } else {
+                                        Spacer(Modifier.weight(1f))
                                     }
                                 }
                             }
@@ -1364,26 +1328,74 @@ private fun ThemePickerDialog(
     }
 }
 
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun ThemeOptionCard(
+    option: me.xdan.aperture.ui.theme.ApertureThemeOption,
+    selected: Boolean,
+    firstRequester: FocusRequester?,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        onClick = { onSelect(option.id) },
+        modifier = modifier
+            .then(if (firstRequester != null) Modifier.focusRequester(firstRequester) else Modifier),
+        shape = ClickableSurfaceDefaults.shape(ApertureTheme.shapes.poster),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            },
+            focusedContainerColor = MaterialTheme.colorScheme.primaryContainer
+        ),
+        scale = ClickableSurfaceDefaults.scale(
+            focusedScale = 1.025f,
+            pressedScale = 0.98f
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = androidx.compose.foundation.BorderStroke(
+                    2.dp,
+                    MaterialTheme.colorScheme.primary
+                ),
+                shape = ApertureTheme.shapes.poster
+            )
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(ApertureTheme.spacing.medium),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            ThemeColourSwatch(option = option, selected = selected)
+            Spacer(Modifier.height(ApertureTheme.spacing.small))
+            Text(
+                text = option.label,
+                style = MaterialTheme.typography.titleSmall,
+                textAlign = TextAlign.Center
+            )
+            if (selected) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    "Selected",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun ThemeColourSwatch(
     option: me.xdan.aperture.ui.theme.ApertureThemeOption,
     selected: Boolean
 ) {
     Canvas(
-        modifier = Modifier
-            .size(88.dp)
-            .border(
-                width = if (selected) 3.dp else 1.dp,
-                color = if (selected) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
-                },
-                shape = CircleShape
-            )
+        modifier = Modifier.size(88.dp)
     ) {
-        // M3-style three-part circular split:
-        // 180° across the top, then 90° bottom-left and 90° bottom-right.
+        val strokeWidth = if (selected) 3.dp.toPx() else 1.dp.toPx()
         drawArc(
             color = option.primary,
             startAngle = 180f,
@@ -1402,12 +1414,10 @@ private fun ThemeColourSwatch(
             sweepAngle = 90f,
             useCenter = true
         )
-        drawArc(
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
-            startAngle = 0f,
-            sweepAngle = 360f,
-            useCenter = false,
-            style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.dp.toPx())
+        drawCircle(
+            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+            radius = size.minDimension / 2f - strokeWidth / 2f,
+            style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeWidth)
         )
     }
 }
@@ -1598,6 +1608,7 @@ private fun SpotlightDaysDialog(
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
                     )
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
+                    
                     var isSliderFocused by remember { mutableStateOf(false) }
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         ExpressiveSlider(
@@ -1617,6 +1628,7 @@ private fun SpotlightDaysDialog(
                             textAlign = TextAlign.Center
                         )
                     }
+                    
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(ApertureTheme.spacing.small),

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.provider.DocumentsContract
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -20,14 +21,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items as gridItems
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.GridCells
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.DeleteSweep
@@ -1334,55 +1334,10 @@ private fun ThemePickerDialog(
                                     modifier = Modifier.padding(ApertureTheme.spacing.medium),
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
-                                    Box(
-                                        modifier = Modifier
-                                            .size(88.dp)
-                                            .border(
-                                                width = if (selected) 3.dp else 1.dp,
-                                                color = if (selected) {
-                                                    MaterialTheme.colorScheme.primary
-                                                } else {
-                                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
-                                                },
-                                                shape = CircleShape
-                                            )
-                                            .background(MaterialTheme.colorScheme.surface, CircleShape)
-                                    ) {
-                                        Box(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .height(48.dp)
-                                                .background(option.primary)
-                                        )
-                                        Row(
-                                            modifier = Modifier
-                                                .align(Alignment.BottomCenter)
-                                                .fillMaxWidth()
-                                                .height(40.dp)
-                                        ) {
-                                            Box(
-                                                modifier = Modifier
-                                                    .weight(1f)
-                                                    .fillMaxSize()
-                                                    .background(option.secondary)
-                                            )
-                                            Box(
-                                                modifier = Modifier
-                                                    .weight(1f)
-                                                    .fillMaxSize()
-                                                    .background(option.tertiary)
-                                            )
-                                        }
-                                        Box(
-                                            modifier = Modifier
-                                                .fillMaxSize()
-                                                .border(
-                                                    width = 1.dp,
-                                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
-                                                    shape = CircleShape
-                                                )
-                                        )
-                                    }
+                                    ThemeColourSwatch(
+                                        option = option,
+                                        selected = selected
+                                    )
                                     Spacer(Modifier.height(ApertureTheme.spacing.small))
                                     Text(
                                         text = option.label,
@@ -1392,7 +1347,7 @@ private fun ThemePickerDialog(
                                     if (selected) {
                                         Spacer(Modifier.height(2.dp))
                                         Text(
-                                            text = "Selected",
+                                            "Selected",
                                             style = MaterialTheme.typography.labelSmall,
                                             color = MaterialTheme.colorScheme.primary
                                         )
@@ -1406,6 +1361,54 @@ private fun ThemePickerDialog(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ThemeColourSwatch(
+    option: me.xdan.aperture.ui.theme.ApertureThemeOption,
+    selected: Boolean
+) {
+    Canvas(
+        modifier = Modifier
+            .size(88.dp)
+            .border(
+                width = if (selected) 3.dp else 1.dp,
+                color = if (selected) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                },
+                shape = CircleShape
+            )
+    ) {
+        // M3-style three-part circular split:
+        // 180° across the top, then 90° bottom-left and 90° bottom-right.
+        drawArc(
+            color = option.primary,
+            startAngle = 180f,
+            sweepAngle = 180f,
+            useCenter = true
+        )
+        drawArc(
+            color = option.secondary,
+            startAngle = 90f,
+            sweepAngle = 90f,
+            useCenter = true
+        )
+        drawArc(
+            color = option.tertiary,
+            startAngle = 0f,
+            sweepAngle = 90f,
+            useCenter = true
+        )
+        drawArc(
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
+            startAngle = 0f,
+            sweepAngle = 360f,
+            useCenter = false,
+            style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.dp.toPx())
+        )
     }
 }
 

--- a/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/screen/settings/SettingsScreen.kt
@@ -1290,7 +1290,7 @@ private fun ThemePickerDialog(
                 Column(Modifier.padding(ApertureTheme.spacing.huge)) {
                     Text("Choose a theme", style = MaterialTheme.typography.headlineSmall)
                     Text(
-                        "Choose a palette for Aperture. Material TV keeps the Google TV look, while the other themes carry their colour through the interface.",
+                        "Choose a palette for Aperture.",
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
                     )
                     Spacer(Modifier.height(ApertureTheme.spacing.large))
@@ -1392,10 +1392,17 @@ private fun ThemeColourSwatch(
     option: me.xdan.aperture.ui.theme.ApertureThemeOption,
     selected: Boolean
 ) {
+    val outlineColor = if (selected) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    }
+
     Canvas(
         modifier = Modifier.size(88.dp)
     ) {
         val strokeWidth = if (selected) 3.dp.toPx() else 1.dp.toPx()
+
         drawArc(
             color = option.primary,
             startAngle = 180f,
@@ -1415,7 +1422,7 @@ private fun ThemeColourSwatch(
             useCenter = true
         )
         drawCircle(
-            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+            color = outlineColor,
             radius = size.minDimension / 2f - strokeWidth / 2f,
             style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeWidth)
         )

--- a/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
@@ -24,7 +24,7 @@ data class ApertureThemeOption(
 
 val ApertureThemeOptions = listOf(
     ApertureThemeOption("purple", "Aperture Purple", Color(0xFFD0BCFF), Color(0xFFCCC2DC), Color(0xFFEFB8C8)),
-    ApertureThemeOption("dynamic", "Artwork Dynamic [PRE-ALPHA]", Color(0xFFB7C8FF), Color(0xFFAFC7E8), Color(0xFFC6B7E8)),
+    ApertureThemeOption("dynamic", "Artwork Dynamic", Color(0xFFB7C8FF), Color(0xFFAFC7E8), Color(0xFFC6B7E8)),
     ApertureThemeOption("classic", "Material TV", Color.White, Color(0xFFE6E1E5), Color(0xFFD0C8D1)),
     ApertureThemeOption("green", "Emerald", Color(0xFF7DDA9A), Color(0xFFA4DDB5), Color(0xFFB9D98B)),
     ApertureThemeOption("red", "Cinema Red", Color(0xFFFFB4AB), Color(0xFFFFC9C3), Color(0xFFFFC17D)),

--- a/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
@@ -117,7 +117,7 @@ fun ApertureTheme(
     // Efficiently update semantic roles when the base Material scheme changes
     apertureColorScheme.updateFrom(scheme.toApertureColorScheme())
 
-    val tokens = remember(apertureColorScheme, themeId) {
+    val tokens = remember(apertureColorScheme, themeId, animatedAccent) {
         ApertureTokens(
             colorScheme = apertureColorScheme,
             typography = ApertureTypography(Typography),

--- a/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
@@ -202,6 +202,8 @@ private fun ColorScheme.toApertureColorScheme(): ApertureColorScheme {
         // Core brand
         primary = primary,
         onPrimary = onPrimary,
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = onPrimaryContainer,
         secondary = secondary,
         background = background,
         onBackground = onBackground,

--- a/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
@@ -12,18 +12,26 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.darkColorScheme
 import me.xdan.aperture.ui.theme.tokens.*
 
-data class ApertureThemeOption(val id: String, val label: String, val preview: Color)
+data class ApertureThemeOption(
+    val id: String,
+    val label: String,
+    val primary: Color,
+    val secondary: Color,
+    val tertiary: Color
+) {
+    val preview: Color get() = primary
+}
 
 val ApertureThemeOptions = listOf(
-    ApertureThemeOption("purple", "Aperture Purple", Color(0xFFD0BCFF)),
-    ApertureThemeOption("dynamic", "Artwork Dynamic [PRE-ALPHA]", Color(0xFFB7C8FF)),
-    ApertureThemeOption("classic", "Material TV", Color(0xFFFFFFFF)),
-    ApertureThemeOption("green", "Emerald", Color(0xFF7DDA9A)),
-    ApertureThemeOption("red", "Cinema Red", Color(0xFFFFB4AB)),
-    ApertureThemeOption("orange", "Sunset Orange", Color(0xFFFFB86B)),
-    ApertureThemeOption("blue", "Electric Blue", Color(0xFFA9C7FF)),
-    ApertureThemeOption("teal", "Ocean Teal", Color(0xFF7CD8D2)),
-    ApertureThemeOption("pink", "Neon Pink", Color(0xFFFFB0D0))
+    ApertureThemeOption("purple", "Aperture Purple", Color(0xFFD0BCFF), Color(0xFFCCC2DC), Color(0xFFEFB8C8)),
+    ApertureThemeOption("dynamic", "Artwork Dynamic [PRE-ALPHA]", Color(0xFFB7C8FF), Color(0xFFAFC7E8), Color(0xFFC6B7E8)),
+    ApertureThemeOption("classic", "Material TV", Color.White, Color(0xFFE6E1E5), Color(0xFFD0C8D1)),
+    ApertureThemeOption("green", "Emerald", Color(0xFF7DDA9A), Color(0xFFA4DDB5), Color(0xFFB9D98B)),
+    ApertureThemeOption("red", "Cinema Red", Color(0xFFFFB4AB), Color(0xFFFFC9C3), Color(0xFFFFC17D)),
+    ApertureThemeOption("orange", "Sunset Orange", Color(0xFFFFB86B), Color(0xFFFFD0A0), Color(0xFFFFC875)),
+    ApertureThemeOption("blue", "Electric Blue", Color(0xFFA9C7FF), Color(0xFFB7D9FF), Color(0xFFBFC1FF)),
+    ApertureThemeOption("teal", "Ocean Teal", Color(0xFF7CD8D2), Color(0xFFA4DCD7), Color(0xFFB8D6A5)),
+    ApertureThemeOption("pink", "Neon Pink", Color(0xFFFFB0D0), Color(0xFFFFC5D9), Color(0xFFD6BCFF))
 )
 
 private val DarkColorScheme = darkColorScheme(
@@ -58,44 +66,66 @@ fun ApertureTheme(
     content: @Composable () -> Unit
 ) {
     val option = ApertureThemeOptions.firstOrNull { it.id == themeId } ?: ApertureThemeOptions.first()
-    val accent = if (themeId == "dynamic") dynamicAccent ?: option.preview else option.preview
+    val accent = if (themeId == "dynamic") dynamicAccent ?: option.primary else option.primary
+    val secondary = if (themeId == "dynamic") accent.copy(alpha = 0.86f) else option.secondary
+    val tertiary = if (themeId == "dynamic") accent.copy(alpha = 0.72f) else option.tertiary
     val animatedAccent = animateColorAsState(
         targetValue = accent,
         animationSpec = tween(durationMillis = 520),
         label = "apertureThemeAccent"
     ).value
-    val scheme = if (themeId == "purple") DarkColorScheme else darkColorScheme(
-        primary = animatedAccent,
-        onPrimary = Color(0xFF151218),
-        primaryContainer = animatedAccent.copy(alpha = 0.30f),
-        onPrimaryContainer = animatedAccent,
-        secondary = animatedAccent.copy(alpha = 0.82f),
-        onSecondary = Color(0xFF151218),
-        secondaryContainer = animatedAccent.copy(alpha = 0.20f),
-        onSecondaryContainer = animatedAccent,
-        background = Color(0xFF111014),
-        onBackground = Color(0xFFF1ECF2),
-        surface = Color(0xFF111014),
-        onSurface = Color(0xFFF1ECF2),
-        surfaceVariant = Color(0xFF252229),
-        onSurfaceVariant = Color(0xFFE6E0E8)
-    )
+    val animatedSecondary = animateColorAsState(
+        targetValue = secondary,
+        animationSpec = tween(durationMillis = 520),
+        label = "apertureThemeSecondary"
+    ).value
+    val animatedTertiary = animateColorAsState(
+        targetValue = tertiary,
+        animationSpec = tween(durationMillis = 520),
+        label = "apertureThemeTertiary"
+    ).value
+
+    val scheme = if (themeId == "purple") {
+        DarkColorScheme
+    } else {
+        darkColorScheme(
+            primary = animatedAccent,
+            onPrimary = if (themeId == "classic") Color(0xFF1A191C) else Color(0xFF151218),
+            primaryContainer = if (themeId == "classic") Color(0xFFE7E2E8) else animatedAccent.copy(alpha = 0.30f),
+            onPrimaryContainer = if (themeId == "classic") Color(0xFF454047) else animatedAccent,
+            secondary = animatedSecondary,
+            onSecondary = Color(0xFF151218),
+            secondaryContainer = if (themeId == "classic") Color(0xFFDCD7DE) else animatedSecondary.copy(alpha = 0.20f),
+            onSecondaryContainer = if (themeId == "classic") Color(0xFF464047) else animatedSecondary,
+            tertiary = animatedTertiary,
+            onTertiary = Color(0xFF20151A),
+            tertiaryContainer = if (themeId == "classic") Color(0xFFD8D2D9) else animatedTertiary.copy(alpha = 0.20f),
+            onTertiaryContainer = if (themeId == "classic") Color(0xFF443D45) else animatedTertiary,
+            background = Color(0xFF111014),
+            onBackground = Color(0xFFF1ECF2),
+            surface = Color(0xFF111014),
+            onSurface = Color(0xFFF1ECF2),
+            surfaceVariant = Color(0xFF252229),
+            onSurfaceVariant = Color(0xFFE6E0E8)
+        )
+    }
 
     val apertureColorScheme = remember {
         scheme.toApertureColorScheme()
     }
-    
+
     // Efficiently update semantic roles when the base Material scheme changes
     apertureColorScheme.updateFrom(scheme.toApertureColorScheme())
 
-    val tokens = remember(apertureColorScheme) {
+    val tokens = remember(apertureColorScheme, themeId) {
         ApertureTokens(
             colorScheme = apertureColorScheme,
             typography = ApertureTypography(Typography),
             shapes = ApertureShapes(),
             motion = ApertureMotion(),
             spacing = ApertureSpacing(),
-            elevation = ApertureElevation()
+            elevation = ApertureElevation(),
+            brandAccent = if (themeId == "classic") Primary else animatedAccent
         )
     }
 
@@ -141,6 +171,11 @@ object ApertureTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalApertureTokens.current.typography
+
+    val brandAccent: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalApertureTokens.current.brandAccent
 }
 
 /**

--- a/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/Theme.kt
@@ -125,7 +125,8 @@ fun ApertureTheme(
             motion = ApertureMotion(),
             spacing = ApertureSpacing(),
             elevation = ApertureElevation(),
-            brandAccent = if (themeId == "classic") Primary else animatedAccent
+            brandAccent = if (themeId == "classic") Primary else animatedAccent,
+            isMaterialTv = themeId == "classic"
         )
     }
 
@@ -176,6 +177,11 @@ object ApertureTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalApertureTokens.current.brandAccent
+
+    val isMaterialTv: Boolean
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalApertureTokens.current.isMaterialTv
 }
 
 /**

--- a/app/src/main/java/me/xdan/aperture/ui/theme/tokens/ApertureTokens.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/tokens/ApertureTokens.kt
@@ -16,7 +16,8 @@ data class ApertureTokens(
     val motion: ApertureMotion,
     val spacing: ApertureSpacing,
     val elevation: ApertureElevation,
-    val brandAccent: Color
+    val brandAccent: Color,
+    val isMaterialTv: Boolean
 )
 
 /**

--- a/app/src/main/java/me/xdan/aperture/ui/theme/tokens/ApertureTokens.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/tokens/ApertureTokens.kt
@@ -1,9 +1,7 @@
 package me.xdan.aperture.ui.theme.tokens
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.tv.material3.Typography
 
 /**
  * The unified token system for Aperture.
@@ -17,7 +15,8 @@ data class ApertureTokens(
     val shapes: ApertureShapes,
     val motion: ApertureMotion,
     val spacing: ApertureSpacing,
-    val elevation: ApertureElevation
+    val elevation: ApertureElevation,
+    val brandAccent: Color
 )
 
 /**

--- a/app/src/main/java/me/xdan/aperture/ui/theme/tokens/Colors.kt
+++ b/app/src/main/java/me/xdan/aperture/ui/theme/tokens/Colors.kt
@@ -30,6 +30,8 @@ class ApertureColorScheme(
     shelfBackground: Color,
     primary: Color,
     onPrimary: Color,
+    primaryContainer: Color,
+    onPrimaryContainer: Color,
     secondary: Color,
     background: Color,
     onBackground: Color,
@@ -68,6 +70,10 @@ class ApertureColorScheme(
         internal set
     var onPrimary by mutableStateOf(onPrimary, structuralEqualityPolicy())
         internal set
+    var primaryContainer by mutableStateOf(primaryContainer, structuralEqualityPolicy())
+        internal set
+    var onPrimaryContainer by mutableStateOf(onPrimaryContainer, structuralEqualityPolicy())
+        internal set
     var secondary by mutableStateOf(secondary, structuralEqualityPolicy())
         internal set
     var background by mutableStateOf(background, structuralEqualityPolicy())
@@ -105,6 +111,8 @@ class ApertureColorScheme(
         shelfBackground = other.shelfBackground
         primary = other.primary
         onPrimary = other.onPrimary
+        primaryContainer = other.primaryContainer
+        onPrimaryContainer = other.onPrimaryContainer
         secondary = other.secondary
         background = other.background
         onBackground = other.onBackground
@@ -134,6 +142,8 @@ class ApertureColorScheme(
         shelfBackground: Color = this.shelfBackground,
         primary: Color = this.primary,
         onPrimary: Color = this.onPrimary,
+        primaryContainer: Color = this.primaryContainer,
+        onPrimaryContainer: Color = this.onPrimaryContainer,
         secondary: Color = this.secondary,
         background: Color = this.background,
         onBackground: Color = this.onBackground,
@@ -158,6 +168,8 @@ class ApertureColorScheme(
         shelfBackground = shelfBackground,
         primary = primary,
         onPrimary = onPrimary,
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = onPrimaryContainer,
         secondary = secondary,
         background = background,
         onBackground = onBackground,


### PR DESCRIPTION
## Summary
- expand theme definitions to use primary, secondary and tertiary colours
- redesign the Settings theme picker as a 3-column colour grid with three-part circular swatches
- keep Material TV visually white while using the purple Aperture logo
- expose the active brand accent through Aperture's expressive token layer

## Notes
This keeps the existing Material TV look as the neutral option while making the other themes carry their colour through the existing TV Material 3 components and Aperture token layer.